### PR TITLE
Optional features for auto-record, save in map seed subdirectories and choosable file formats

### DIFF
--- a/changelog.txt
+++ b/changelog.txt
@@ -1,4 +1,13 @@
 ---------------------------------------------------------------------------------------------------
+Version: 2.1.0
+Date: 19-02-2025
+  Features:
+    - Add (per player) setting to automatically activate recording with main camera on new game
+    - Add (per player) setting to save screenshots in map seed named subdirectories
+    - Add (per player) setting to change screenshot format (png/jpg)
+  Bugfixes:
+    - Fix main camera producing screenshot files with wrong camera name
+---------------------------------------------------------------------------------------------------
 Version: 2.0.4
 Date: 07-11-2024
   Bugfixes:

--- a/control.lua
+++ b/control.lua
@@ -21,7 +21,9 @@ local function init_new_player(index, player)
     TLBE.GUI.initialize(player, storage.playerSettings[index])
 
     player.print({ "mod-loaded" }, { r = 1, g = 0.5, b = 0 })
-    player.print({ "mod-loaded2" })
+    if not player.autoRecord then
+        player.print({ "mod-loaded2" })
+    end
 end
 
 local function on_init()
@@ -71,7 +73,9 @@ local function on_player_created(event)
     TLBE.Config.reload(event)
 
     local player = game.players[event.player_index]
-    player.print({ "mod-loaded2" }, { r = 1, g = 0.5, b = 0 })
+    if not player.autoRecord then
+        player.print({ "mod-loaded2" }, { r = 1, g = 0.5, b = 0 })
+    end
 
     TLBE.GUI.initialize(player, storage.playerSettings[event.player_index])
 end

--- a/control.lua
+++ b/control.lua
@@ -21,7 +21,9 @@ local function init_new_player(index, player)
     TLBE.GUI.initialize(player, storage.playerSettings[index])
 
     player.print({ "mod-loaded" }, { r = 1, g = 0.5, b = 0 })
-    if not player.autoRecord then
+
+    local playerSettings = storage.playerSettings[index]
+    if not playerSettings.autoRecord then
         player.print({ "mod-loaded2" })
     end
 end
@@ -73,7 +75,8 @@ local function on_player_created(event)
     TLBE.Config.reload(event)
 
     local player = game.players[event.player_index]
-    if not player.autoRecord then
+    local playerSettings = storage.playerSettings[event.player_index]
+    if not playerSettings.autoRecord then
         player.print({ "mod-loaded2" }, { r = 1, g = 0.5, b = 0 })
     end
 

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -102,7 +102,8 @@ tlbe-sequential-names=Sequential names
 tlbe-show-stats=Show camera status
 tlbe-use-interval=Use interval as speed setting
 tlbe-auto-record=Automatic recording
-tlbe-seed-subfolder=Map-Seed Subfolder
+tlbe-seed-subfolder=Map-Seed subfolder
+tlbe-save-format=Image format
 
 [mod-setting-description]
 tlbe-save-folder=Relative from 'User Data Directory'
@@ -111,6 +112,7 @@ tlbe-show-stats=This requires the Stats GUI mod to be loaded.
 tlbe-use-interval=Use intervals (between frames) instead of speed gain in the camera settings. When this setting is changed, reopen camera settings to update the UI.
 tlbe-auto-record=Start recording automatically with main camera on new game
 tlbe-seed-subfolder=Generate a subfolder for each map seed
+tlbe-save-format=Format of screenshot files
 
 [shortcut]
 tlbe=Time Lapse Base Edition

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -102,7 +102,7 @@ tlbe-sequential-names=Sequential names
 tlbe-show-stats=Show camera status
 tlbe-use-interval=Use interval as speed setting
 tlbe-auto-record=Automatic recording
-tlbe-seed-subfolder=Map-Seed subfolder
+tlbe-seed-subfolder=Map seed subfolder
 tlbe-save-format=Image format
 
 [mod-setting-description]
@@ -111,7 +111,7 @@ tlbe-sequential-names=Use sequential numbering per camera for the screenshot num
 tlbe-show-stats=This requires the Stats GUI mod to be loaded.
 tlbe-use-interval=Use intervals (between frames) instead of speed gain in the camera settings. When this setting is changed, reopen camera settings to update the UI.
 tlbe-auto-record=Start recording automatically with main camera on new game
-tlbe-seed-subfolder=Generate a subfolder for each map seed
+tlbe-seed-subfolder=Generate a subfolder for each map seed to store screenshots in
 tlbe-save-format=Format of screenshot files
 
 [shortcut]

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -101,12 +101,14 @@ tlbe-save-folder=Save location
 tlbe-sequential-names=Sequential names
 tlbe-show-stats=Show camera status
 tlbe-use-interval=Use interval as speed setting
+tlbe-auto-record=Automatic recording
 
 [mod-setting-description]
 tlbe-save-folder=Relative from 'User Data Directory'
 tlbe-sequential-names=Use sequential numbering per camera for the screenshot numbers. When disabled, game ticks are used for screenshot numbering.
 tlbe-show-stats=This requires the Stats GUI mod to be loaded.
 tlbe-use-interval=Use intervals (between frames) instead of speed gain in the camera settings. When this setting is changed, reopen camera settings to update the UI.
+tlbe-auto-record=Start recording automatically with main camera on new game
 
 [shortcut]
 tlbe=Time Lapse Base Edition

--- a/locale/en/locale.cfg
+++ b/locale/en/locale.cfg
@@ -102,6 +102,7 @@ tlbe-sequential-names=Sequential names
 tlbe-show-stats=Show camera status
 tlbe-use-interval=Use interval as speed setting
 tlbe-auto-record=Automatic recording
+tlbe-seed-subfolder=Map-Seed Subfolder
 
 [mod-setting-description]
 tlbe-save-folder=Relative from 'User Data Directory'
@@ -109,6 +110,7 @@ tlbe-sequential-names=Use sequential numbering per camera for the screenshot num
 tlbe-show-stats=This requires the Stats GUI mod to be loaded.
 tlbe-use-interval=Use intervals (between frames) instead of speed gain in the camera settings. When this setting is changed, reopen camera settings to update the UI.
 tlbe-auto-record=Start recording automatically with main camera on new game
+tlbe-seed-subfolder=Generate a subfolder for each map seed
 
 [shortcut]
 tlbe=Time Lapse Base Edition

--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -56,7 +56,7 @@ function Config.newPlayerSettings(player)
 
     local camera = Camera.newCamera(player, {})
     camera.name = "main"
-    camera.enabled = guiSettings["tlbe-auto-record"].value
+    camera.enabled = settings.get_player_settings(player)["tlbe-auto-record"].value
     camera.trackers = { trackers[1], trackers[2], trackers[3] }
 
     return {

--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -43,6 +43,7 @@ function Config.reload(event)
     playerSettings.sequentialNames = guiSettings["tlbe-sequential-names"].value
     playerSettings.showCameraStatus = guiSettings["tlbe-show-stats"].value
     playerSettings.useInterval = guiSettings["tlbe-use-interval"].value
+    playerSettings.autoRecord = guiSettings["tlbe-auto-record"].value
     playerSettings.seedSubfolder = guiSettings["tlbe-seed-subfolder"].value
     playerSettings.saveFormat = guiSettings["tlbe-save-format"].value
     ---@diagnostic enable: assign-type-mismatch

--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -34,7 +34,7 @@ function Config.reload(event)
     local playerSettings = storage.playerSettings[event.player_index]
     if playerSettings == nil then
         playerSettings = Config.newPlayerSettings(player)
-        playerSettings.cameras[1] = guiSettings["tlbe-auto-record"].value
+        playerSettings.cameras[playerSettings.guiPersist.selectedCamera].enabled = guiSettings["tlbe-auto-record"].value
         storage.playerSettings[event.player_index] = playerSettings
     end
 

--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -56,7 +56,7 @@ function Config.newPlayerSettings(player)
     }
 
     local camera = Camera.newCamera(player, {})
-    camera.name = "main"
+    Camera.setName(camera, "main")
     camera.enabled = settings.get_player_settings(player)["tlbe-auto-record"].value
     camera.trackers = { trackers[1], trackers[2], trackers[3] }
 

--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -44,6 +44,7 @@ function Config.reload(event)
     playerSettings.showCameraStatus = guiSettings["tlbe-show-stats"].value
     playerSettings.useInterval = guiSettings["tlbe-use-interval"].value
     playerSettings.seedSubfolder = guiSettings["tlbe-seed-subfolder"].value
+    playerSettings.saveFormat = guiSettings["tlbe-save-format"].value
     ---@diagnostic enable: assign-type-mismatch
 end
 

--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -56,6 +56,7 @@ function Config.newPlayerSettings(player)
 
     local camera = Camera.newCamera(player, {})
     camera.name = "main"
+    camera.enabled = guiSettings["tlbe-auto-record"].value
     camera.trackers = { trackers[1], trackers[2], trackers[3] }
 
     return {

--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -34,6 +34,7 @@ function Config.reload(event)
     local playerSettings = storage.playerSettings[event.player_index]
     if playerSettings == nil then
         playerSettings = Config.newPlayerSettings(player)
+        playerSettings.cameras[1] = guiSettings["tlbe-auto-record"].value
         storage.playerSettings[event.player_index] = playerSettings
     end
 
@@ -57,7 +58,6 @@ function Config.newPlayerSettings(player)
 
     local camera = Camera.newCamera(player, {})
     Camera.setName(camera, "main")
-    camera.enabled = settings.get_player_settings(player)["tlbe-auto-record"].value
     camera.trackers = { trackers[1], trackers[2], trackers[3] }
 
     return {

--- a/scripts/config.lua
+++ b/scripts/config.lua
@@ -42,6 +42,7 @@ function Config.reload(event)
     playerSettings.sequentialNames = guiSettings["tlbe-sequential-names"].value
     playerSettings.showCameraStatus = guiSettings["tlbe-show-stats"].value
     playerSettings.useInterval = guiSettings["tlbe-use-interval"].value
+    playerSettings.seedSubfolder = guiSettings["tlbe-seed-subfolder"].value
     ---@diagnostic enable: assign-type-mismatch
 end
 

--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -168,19 +168,22 @@ function Main.takeScreenshot(player, playerSettings, camera, activeTracker, forc
     local savePath
     if playerSettings.seedSubfolder then
         savePath = string.format(
-            "%s/%s/%d/%010d-%s.png",
+            "%s/%s/%d/%010d-%s.%s",
             playerSettings.saveFolder,
             camera.saveFolder,
             game.default_map_gen_settings.seed,
-            screenshotNumber, camera.saveName
+            screenshotNumber,
+            camera.saveName,
+            playerSettings.saveFormat
         )
     else
         savePath = string.format(
-            "%s/%s/%010d-%s.png",
+            "%s/%s/%010d-%s.%s",
             playerSettings.saveFolder,
             camera.saveFolder,
             screenshotNumber,
-            camera.saveName
+            camera.saveName,
+            playerSettings.saveFormat
         )
     end
 

--- a/scripts/main.lua
+++ b/scripts/main.lua
@@ -165,14 +165,32 @@ function Main.takeScreenshot(player, playerSettings, camera, activeTracker, forc
         alwaysDay = nil
     end
 
+    local savePath
+    if playerSettings.seedSubfolder then
+        savePath = string.format(
+            "%s/%s/%d/%010d-%s.png",
+            playerSettings.saveFolder,
+            camera.saveFolder,
+            game.default_map_gen_settings.seed,
+            screenshotNumber, camera.saveName
+        )
+    else
+        savePath = string.format(
+            "%s/%s/%010d-%s.png",
+            playerSettings.saveFolder,
+            camera.saveFolder,
+            screenshotNumber,
+            camera.saveName
+        )
+    end
+
     game.take_screenshot {
         by_player = player,
         surface = camera.surfaceName or game.surfaces[1],
         position = camera.centerPos,
         resolution = { camera.width, camera.height },
         zoom = camera.zoom,
-        path = string.format("%s/%s/%010d-%s.png", playerSettings.saveFolder, camera.saveFolder, screenshotNumber
-        , camera.saveName),
+        path = savePath,
         show_entity_info = camera.entityInfo,
         show_gui = camera.showGUI,
         allow_in_replay = true,

--- a/settings.lua
+++ b/settings.lua
@@ -34,6 +34,13 @@ data:extend(
             setting_type = "runtime-per-user",
             default_value = false,
             order = "12"
+        },
+        {
+            type = "bool-setting",
+            name = "tlbe-seed-subfolder",
+            setting_type = "runtime-per-user",
+            default_value = false,
+            order = "15"
         }
     }
 )

--- a/settings.lua
+++ b/settings.lua
@@ -41,6 +41,14 @@ data:extend(
             setting_type = "runtime-per-user",
             default_value = false,
             order = "15"
+        },
+        {
+            type = "string-setting",
+            name = "tlbe-save-format",
+            setting_type = "runtime-per-user",
+            default_value = "png",
+            allowed_values = { "png", "jpg" },
+            order = "18"
         }
     }
 )

--- a/settings.lua
+++ b/settings.lua
@@ -27,6 +27,13 @@ data:extend(
             setting_type = "runtime-per-user",
             default_value = false,
             order = "9"
+        },
+        {
+            type = "bool-setting",
+            name = "tlbe-auto-record",
+            setting_type = "runtime-per-user",
+            default_value = false,
+            order = "12"
         }
     }
 )

--- a/settings.lua
+++ b/settings.lua
@@ -33,14 +33,14 @@ data:extend(
             name = "tlbe-auto-record",
             setting_type = "runtime-per-user",
             default_value = false,
-            order = "12"
+            order = "13"
         },
         {
             type = "bool-setting",
             name = "tlbe-seed-subfolder",
             setting_type = "runtime-per-user",
             default_value = false,
-            order = "15"
+            order = "4"
         },
         {
             type = "string-setting",
@@ -48,7 +48,7 @@ data:extend(
             setting_type = "runtime-per-user",
             default_value = "png",
             allowed_values = { "png", "jpg" },
-            order = "18"
+            order = "2"
         }
     }
 )


### PR DESCRIPTION
I made some changes with features I wanted. Everything is optional and has to be enabled in the mod-settings.
The default behaviour of the mod is unchanged (except for the bugfix ofc).

- Added option to auto start recordings with the main camera when starting a new game
- Added option to auto create subdirectories named after the map seed to easily save screenshots for multiple save games
- Added option to choose file format (png or jpg) to have an option with smaller file sizes
- Fixed a bug that named screenshot files as "new-camera" when main camera was used

My intention with these changes was to make a more hand-off style of use possible.
I played a few hours without issue and tryed to test the changes to the best of my abilities.